### PR TITLE
Use SPDX license identifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 \#*
 *.bak
 .idea/
+vendor/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "xoops/base-requires25",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "type": "project",
     "description": "Primary dependencies for XOOPS/XoopsCore25",
     "require": {


### PR DESCRIPTION
- SPDX license now required by packagist.org
- some git housekeeping